### PR TITLE
Install more packages to fnal-dev-sl7 container

### DIFF
--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -11,7 +11,7 @@ RUN yum -y install asciidoc autoconf automake bzip2-devel fontconfig-devel freet
     libuuid-devel libxkbcommon-devel libxkbcommon-x11-devel lz4-devel ncurses-devel openldap-devel perl-DBD-SQLite perl-ExtUtils-MakeMaker readline-devel \
     subversion swig tcl-devel texinfo tk-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel xmlto xxhash-devel zstd
 
-RUN yum -y install python-six \
+RUN yum -y install python-six emacs vim \
     && yum -y clean all
 
 RUN yum -y install yum-conf-context-fermilab.noarch

--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -15,7 +15,7 @@ RUN yum -y install python-six emacs vim \
     && yum -y clean all
 
 RUN yum -y install yum-conf-context-fermilab.noarch
-RUN yum -y install fermilab-util_kx509 \
+RUN yum -y install fermilab-util_kx509 fermilab-conf_kerberos \
     && yum -y clean all
 
 # Default entry point

--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -9,7 +9,9 @@ LABEL description="SL7 development container"
 RUN yum -y install asciidoc autoconf automake bzip2-devel fontconfig-devel freetype-devel ftgl-devel gdbm-devel giflib-devel gl2ps-devel glew-devel glibc-devel.i686 \
     harfbuzz-devel libAfterImage-devel libXft-devel libXi-devel libXrender-devel libgcc.i686 libjpeg-turbo-devel libpng-devel libstdc++-devel.i686 libtool \
     libuuid-devel libxkbcommon-devel libxkbcommon-x11-devel lz4-devel ncurses-devel openldap-devel perl-DBD-SQLite perl-ExtUtils-MakeMaker readline-devel \
-    subversion swig tcl-devel texinfo tk-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel xmlto xxhash-devel zstd \
+    subversion swig tcl-devel texinfo tk-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel xmlto xxhash-devel zstd
+
+RUN yum -y install python-six \
     && yum -y clean all
 
 RUN yum -y install yum-conf-context-fermilab.noarch


### PR DESCRIPTION
Install `python-six`. This packages is needed by kx509/cigetcert from Fermilab common UPS area. Those are set up as dependencies of fife_utils and possibly also by other packages that are commonly set up by users.
We also add `emacs` and `vim` editors, and fermilab-conf_kerberos for the standard FNAL `/etc/krb5.conf`.