### PR TITLE
Changed /usr/bin/ssh-agent to be readable by everyone to avoid error

### DIFF
--- a/worker/fnal-wn-sl7/Dockerfile
+++ b/worker/fnal-wn-sl7/Dockerfile
@@ -60,7 +60,8 @@ RUN yum install -y \
     jq \
     globus-gass-copy-progs globus-proxy-utils globus-xio-udt-driver gfal2-plugin-gridftp gfal2-plugin-srm uberftp \
     fts-client gsi-openssh-clients myproxy voms-clients-cpp stashcp \
-    python-setuptools python2-future python-backports-ssl_match_hostname python2-gfal2-util
+    python-setuptools python2-future python-backports-ssl_match_hostname python2-gfal2-util && \
+    chmod ugo+rx /usr/bin/ssh-agent
 
 # Installing apptainer 1.2.5 (+requirements) and not 1.3 from EPEL, to be able to use underlay on EL7 nodes
 RUN yum install -y fuse2fs && \


### PR DESCRIPTION
Changed /usr/bin/ssh-agent to be readable by everyone to avoid invocation error in Apptainer

Apptainer is ignoring SGID and it is failing the invocation if you are not the owner of the file. Giving read access is a tested workaround. See https://github.com/glideinWMS/containers/issues/28 for a discussion

This fixes #28 