### PR TITLE
Remove libpq-devel from Dockerfile

### DIFF
--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -10,7 +10,7 @@ RUN yum -y install asciidoc autoconf automake bzip2-devel fontconfig-devel freet
     harfbuzz-devel libAfterImage-devel libXft-devel libXi-devel libXrender-devel libgcc.i686 libjpeg-turbo-devel libpng-devel libstdc++-devel.i686 libtool \
     libuuid-devel libxkbcommon-devel libxkbcommon-x11-devel lz4-devel ncurses-devel openldap-devel perl-DBD-SQLite perl-ExtUtils-MakeMaker readline-devel \
     subversion swig tcl-devel texinfo tk-devel xcb-util-image-devel xcb-util-keysyms-devel xcb-util-renderutil-devel xcb-util-wm-devel xmlto xxhash-devel zstd \
-    gtk2-devel motif-devel postgresql-devel libpq-devel sqlite-devel \
+    gtk2-devel motif-devel postgresql-devel sqlite-devel \
     python3-devel python-six emacs vim nano screen cvs htop curl procmail \
     autogen bison cmake3 gunzip hwloc-devel patchelf ninja-build csh tcsh zsh \
     java-latest-openjdk-devel \


### PR DESCRIPTION
The package libpq-devel does not exists, removing it from the Dockerfile.