### PR TITLE
Update repo files with updated repo URLs after SL7 EOL

### DIFF
--- a/worker/fnal-wn-sl7/Dockerfile
+++ b/worker/fnal-wn-sl7/Dockerfile
@@ -6,6 +6,14 @@ FROM scientificlinux/sl:7
 MAINTAINER Marco Mambelli "marcom@fnal.gov"
 LABEL name="FNAL Worker Node on SL7 with OSG 3.6 Worker Node Client"
 
+# copy over updated repo files with updated repo URLs after SL7 EOL
+COPY repos/fermilab.repo        /etc/yum.repos.d/fermilab.repo
+COPY repos/repos.repo           /etc/yum.repos.d/repos.repo
+COPY repos/sl7-fastbugs.repo    /etc/yum.repos.d/sl7-fastbugs.repo
+COPY repos/sl7.repo             /etc/yum.repos.d/sl7.repo
+COPY repos/sl7-security.repo    /etc/yum.repos.d/sl7-security.repo
+COPY repos/sl-extras.repo       /etc/yum.repos.d/sl-extras.repo
+
 # Setting up the HTCondor Madison repository
 # Technically, HTCondor isn't installed but this has been done
 # to keep in sync with other Docker file and keep the source of

--- a/worker/fnal-wn-sl7/repos/fermilab.repo
+++ b/worker/fnal-wn-sl7/repos/fermilab.repo
@@ -1,0 +1,11 @@
+[fermilab]
+Name=Scientific Linux Context - Fermilab - $basearch
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/7/contexts/fermilab/$basearch/
+        http://ftp1.scientificlinux.org/linux/scientific/obsolete/7/contexts/fermilab/$basearch/
+        http://ftp2.scientificlinux.org/linux/scientific/obsolete/7/contexts/fermilab/$basearch/
+#mirrorlist=http://ftp.scientificlinux.org/linux/scientific/obsolete/7/contexts/fermilab/mirrors/base
+
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-context-fermilab
+

--- a/worker/fnal-wn-sl7/repos/repos.repo
+++ b/worker/fnal-wn-sl7/repos/repos.repo
@@ -1,0 +1,20 @@
+[repos]
+Name=Scientific Linux repos - $basearch
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/7x/repos/$basearch/
+        http://ftp1.scientificlinux.org/linux/scientific/obsolete/7x/repos/$basearch/
+        http://ftp2.scientificlinux.org/linux/scientific/obsolete/7x/repos/$basearch/
+
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7
+
+[repos-source]
+Name=Scientific Linux repos - source
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/7x/repos/SRPMS/
+        http://ftp1.scientificlinux.org/linux/scientific/obsolete/7x/repos/SRPMS/
+        http://ftp2.scientificlinux.org/linux/scientific/obsolete/7x/repos/SRPMS/
+
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7
+

--- a/worker/fnal-wn-sl7/repos/sl-extras.repo
+++ b/worker/fnal-wn-sl7/repos/sl-extras.repo
@@ -1,0 +1,30 @@
+[sl-extras]
+Name=Scientific Linux Extras - $basearch
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/$basearch/
+        http://ftp1.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/$basearch/
+        http://ftp2.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/$basearch/
+
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7
+
+[sl-extras-debuginfo]
+Name=Scientific Linux Extras - debuginfo
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/$basearch/debuginfo/
+        http://ftp1.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/$basearch/debuginfo/
+        http://ftp2.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/$basearch/debuginfo/
+
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7
+
+[sl-extras-source]
+Name=Scientific Linux Extras - source
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/SRPMS/
+        http://ftp1.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/SRPMS/
+        http://ftp2.scientificlinux.org/linux/scientific/obsolete/7x/external_products/extras/SRPMS/
+
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7
+

--- a/worker/fnal-wn-sl7/repos/sl7-fastbugs.repo
+++ b/worker/fnal-wn-sl7/repos/sl7-fastbugs.repo
@@ -1,0 +1,10 @@
+[sl-fastbugs]
+name=Scientific Linux $slreleasever - $basearch - bugfix updates
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/fastbugs/
+                http://ftp1.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/fastbugs/
+                http://ftp2.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/fastbugs/
+                ftp://ftp.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/fastbugs/
+#mirrorlist=http://ftp.scientificlinux.org/linux/scientific/obsolete/mirrorlist/sl-fastbugs-7.txt
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7

--- a/worker/fnal-wn-sl7/repos/sl7-security.repo
+++ b/worker/fnal-wn-sl7/repos/sl7-security.repo
@@ -1,0 +1,10 @@
+[sl-security]
+name=Scientific Linux $slreleasever - $basearch - security updates
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/security/
+                http://ftp1.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/security/
+                http://ftp2.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/security/
+                ftp://ftp.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/updates/security/
+#mirrorlist=http://ftp.scientificlinux.org/linux/scientific/obsolete/mirrorlist/sl-security-7.txt
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7

--- a/worker/fnal-wn-sl7/repos/sl7.repo
+++ b/worker/fnal-wn-sl7/repos/sl7.repo
@@ -1,0 +1,10 @@
+[sl]
+name=Scientific Linux $slreleasever - $basearch
+baseurl=http://ftp.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/os/
+                http://ftp1.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/os/
+                http://ftp2.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/os/
+                ftp://ftp.scientificlinux.org/linux/scientific/obsolete/$slreleasever/$basearch/os/
+#mirrorlist=http://ftp.scientificlinux.org/linux/scientific/obsolete/mirrorlist/sl-base-7.txt
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl file:///etc/pki/rpm-gpg/RPM-GPG-KEY-sl7


### PR DESCRIPTION
After SL7 EOL many of its repo URLs are broken, now repos are archived in obsolete folder.
This PR is updating repo URLs to take this into account.