### PR TITLE
Update script paths to use /opt instead of /root

### DIFF
--- a/workspaces/README.md
+++ b/workspaces/README.md
@@ -75,11 +75,11 @@ Other useful commands:
 ```bash
 podman ps -a
 podman images
-podman exec -it ce-workspace.glideinwms.org /root/scripts/startup.sh
-podman exec -it factory-workspace.glideinwms.org /root/scripts/startup.sh
-podman exec -it frontend-workspace.glideinwms.org /root/scripts/startup.sh
+podman exec -it ce-workspace.glideinwms.org /opt/scripts/startup.sh
+podman exec -it factory-workspace.glideinwms.org /opt/scripts/startup.sh
+podman exec -it frontend-workspace.glideinwms.org /opt/scripts/startup.sh
 # Remember to authenticate at the URL to validate the SciToken! 
-podman exec -it frontend-workspace.glideinwms.org /root/scripts/run-test.sh
+podman exec -it frontend-workspace.glideinwms.org /opt/scripts/run-test.sh
 
 podman exec -it ce-workspace.glideinwms.org /bin/bash
 podman exec -it factory-workspace.glideinwms.org /bin/bash

--- a/workspaces/ce-workspace/Dockerfile
+++ b/workspaces/ce-workspace/Dockerfile
@@ -40,9 +40,9 @@ RUN dnf -y install htcondor-ce-condor
 RUN rm -rf /var/cache/yum/* /var/cache/dnf/* /root/.cache/pip/*
 
 # Deploy utility scripts
-COPY ce-workspace/scripts /root/scripts
-COPY shared/scripts/create-host-certificate.sh /root/scripts/
-RUN ln -s /root/scripts/* /usr/local/bin
+COPY ce-workspace/scripts /opt/scripts
+COPY shared/scripts/create-host-certificate.sh /opt/scripts/
+RUN ln -s /opt/scripts/* /usr/local/bin
 
 # Deploy HTCondor-CE configuration
 COPY ce-workspace/config/10-local.conf /etc/condor/config.d/10-local.conf

--- a/workspaces/ce-workspace/scripts/startup.sh
+++ b/workspaces/ce-workspace/scripts/startup.sh
@@ -5,7 +5,7 @@
 
 GWMS_DIR=/opt/gwms
 
-bash /root/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
+bash /opt/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
 
 systemctl start condor
 systemctl start condor-ce

--- a/workspaces/factory-workspace/Dockerfile
+++ b/workspaces/factory-workspace/Dockerfile
@@ -44,9 +44,9 @@ RUN rm -f /etc/condor/config.d/00-minicondor
 RUN rm -rf /var/cache/yum/* /var/cache/dnf/* /root/.cache/pip/*
 
 # Deploy utility scripts
-COPY shared/scripts /root/scripts
-COPY factory-workspace/scripts/* /root/scripts
-RUN ln -s /root/scripts/* /usr/local/bin
+COPY shared/scripts /opt/scripts
+COPY factory-workspace/scripts/* /opt/scripts
+RUN ln -s /opt/scripts/* /usr/local/bin
 
 # Download HTCondor tarballs
 # HTCondor 10.6.0 to test a more recent version on Alma9

--- a/workspaces/factory-workspace/scripts/startup.sh
+++ b/workspaces/factory-workspace/scripts/startup.sh
@@ -43,10 +43,10 @@ done
 if $FULL_STARTUP; then
     # Just the first time
     [[ -n "$VERBOSE" ]] && echo "Full startup" || true
-    bash /root/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
+    bash /opt/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
     # shellcheck disable=SC2086   # Options are unquoted to allow globbing
-    $DO_LINK_GIT && bash /root/scripts/link-git.sh -a -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
-    bash /root/scripts/create-idtokens.sh -a
+    $DO_LINK_GIT && bash /opt/scripts/link-git.sh -a -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
+    bash /opt/scripts/create-idtokens.sh -a
     systemctl start httpd
     systemctl start condor
 else
@@ -54,7 +54,7 @@ else
     [[ -n "$VERBOSE" ]] && echo "Refresh only" || true
     systemctl stop gwms-factory
     # shellcheck disable=SC2086   # Options are unquoted to allow globbing
-    $DO_LINK_GIT && bash /root/scripts/link-git.sh -a -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
+    $DO_LINK_GIT && bash /opt/scripts/link-git.sh -a -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
     systemctl restart condor  # in case the configuration changes
 fi
 # All the times

--- a/workspaces/frontend-workspace/Dockerfile
+++ b/workspaces/frontend-workspace/Dockerfile
@@ -44,9 +44,9 @@ RUN rm -f /etc/condor/config.d/00-minicondor
 RUN rm -rf /var/cache/yum/* /var/cache/dnf/* /root/.cache/pip/*
 
 # Deploy utility scripts
-COPY shared/scripts /root/scripts
-COPY frontend-workspace/scripts/* /root/scripts/
-RUN ln -s /root/scripts/* /usr/local/bin
+COPY shared/scripts /opt/scripts
+COPY frontend-workspace/scripts/* /opt/scripts/
+RUN ln -s /opt/scripts/* /usr/local/bin
 
 # Deploy GlideinWMS Frontend and HTCondor configuration
 COPY frontend-workspace/config/frontend.xml /etc/gwms-frontend/frontend.xml

--- a/workspaces/frontend-workspace/scripts/startup.sh
+++ b/workspaces/frontend-workspace/scripts/startup.sh
@@ -42,10 +42,10 @@ done
 if $FULL_STARTUP; then
     # First time only
     [[ -n "$VERBOSE" ]] && echo "Full startup" || true
-    bash /root/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
+    bash /opt/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
     # shellcheck disable=SC2086   # Options are unquoted to allow globbing
-    $DO_LINK_GIT && bash /root/scripts/link-git.sh -r -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
-    bash /root/scripts/create-idtokens.sh -r
+    $DO_LINK_GIT && bash /opt/scripts/link-git.sh -r -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
+    bash /opt/scripts/create-idtokens.sh -r
     systemctl start httpd
     systemctl start condor
 else
@@ -53,11 +53,11 @@ else
     [[ -n "$VERBOSE" ]] && echo "Refresh only" || true
     systemctl stop gwms-frontend
     # shellcheck disable=SC2086   # Options are unquoted to allow globbing
-    $DO_LINK_GIT && bash /root/scripts/link-git.sh -r -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
+    $DO_LINK_GIT && bash /opt/scripts/link-git.sh -r -d "$GWMS_DIR" $GWMS_REPO $GWMS_REPO_REF || true
     systemctl restart condor  # in case the configuration changes
 fi
 # All the times
 # Always recreate the scitoken (expires quickly, OK to have a new one)
-bash /root/scripts/create-scitoken.sh
+bash /opt/scripts/create-scitoken.sh
 gwms-frontend upgrade
 systemctl start gwms-frontend


### PR DESCRIPTION
This pull request includes changes to update the paths for utility scripts from `/root/scripts` to `/opt/scripts` across multiple files and directories. The changes ensure consistency in script locations, improve maintainability, and allow for external customization.