### PR TITLE
Add testbed workspace

### DIFF
--- a/workspaces/compose-testbed.yml
+++ b/workspaces/compose-testbed.yml
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2020 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# This compose file deploys a simple test environment with a CE, Factory, and Frontend.
+# The Factory and Frontend containers use the gwms-base image. GlideinWMS is installed with startup-from-rpm.sh.
+
+# IMAGE_NAMESPACE: 'glideinwms'
+# IMAGE_LABEL: 'latest'
+
+services:
+
+  ce-workspace:
+    container_name: testbed-ce-workspace.glideinwms.org
+    build:
+      context: .
+      cache_from:
+        - ${IMAGE_NAMESPACE-glideinwms}/ce-workspace:${IMAGE_LABEL-latest}
+      dockerfile: ce-workspace/Dockerfile
+    image: ${IMAGE_NAMESPACE-glideinwms}/ce-workspace:${IMAGE_LABEL-latest}
+    networks:
+      - gwms
+    hostname: ce-workspace.glideinwms.org
+    tty: true
+    stdin_open: true
+    stop_grace_period: 2s
+
+  factory-workspace:
+    container_name: testbed-factory-workspace.glideinwms.org
+    build:
+      context: .
+      cache_from:
+        - ${IMAGE_NAMESPACE-glideinwms}/testbed-workspace:${IMAGE_LABEL-latest}
+      dockerfile: testbed-workspace/Dockerfile
+    image: ${IMAGE_NAMESPACE-glideinwms}/testbed-workspace:${IMAGE_LABEL-latest}
+    volumes:
+      - gwms-tokens:/var/lib/gwms-factory/.condor/tokens.d
+    networks:
+      - gwms
+    hostname: factory-workspace.glideinwms.org
+    depends_on:
+      - ce-workspace
+    tty: true
+    stdin_open: true
+    stop_grace_period: 2s
+
+  frontend-workspace:
+    container_name: testbed-frontend-workspace.glideinwms.org
+    build:
+      context: .
+      cache_from:
+        - ${IMAGE_NAMESPACE-glideinwms}/testbed-workspace:${IMAGE_LABEL-latest}
+      dockerfile: testbed-workspace/Dockerfile
+    image: ${IMAGE_NAMESPACE-glideinwms}/testbed-workspace:${IMAGE_LABEL-latest}
+    volumes:
+      - gwms-tokens:/var/lib/gwms-frontend/.condor/tokens.d
+    networks:
+      - gwms
+    hostname: frontend-workspace.glideinwms.org
+    depends_on:
+      - ce-workspace
+    tty: true
+    stdin_open: true
+    stop_grace_period: 2s
+
+
+volumes:
+
+  gwms-tokens:
+    driver: local
+
+networks:
+
+  gwms:
+    driver: bridge

--- a/workspaces/testbed-workspace/Dockerfile
+++ b/workspaces/testbed-workspace/Dockerfile
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2020 Fermi Research Alliance, LLC
+# SPDX-License-Identifier: Apache-2.0
+
+# Selecting AlmaLinux 9 as the base OS
+FROM almalinux:9
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG BUILD_VERSION=dev
+ARG BUILD_REF
+ARG BUILD_HASH
+ARG BUILD_SHA
+ARG BUILD_DATE
+ARG GWMS_VERSION=latest
+# MAINTAINER is deprecated but it is needed to set Author in the image attributes
+MAINTAINER GlideinWMS Team <glideinwms@fnal.gov>
+LABEL name="Testbed workspace with EL9 and utility scripts" \
+      org.opencontainers.image.authors="GlideinWMS Team glideinwms@fnal.gov" \
+      org.opencontainers.image.title="GWMS Testbed Workspace" \
+      org.opencontainers.image.description="Testbed workspace with EL9 and utility scripts" \
+      org.opencontainers.image.url="https://glideinwms.fnal.gov/" \
+      org.opencontainers.image.documentation="https://glideinwms.fnal.gov/" \
+      org.opencontainers.image.source="https://github.com/glideinWMS/containers/tree/main/workspaces" \
+      org.opencontainers.image.vendor="The GlideinWMS Team" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.revision="$BUILD_HASH" \
+      org.opencontainers.image.ref.name="$BUILD_REF" \
+      org.opencontainers.image.created="$BUILD_DATE"\
+      org.glideinwms.image.version="$GWMS_VERSION"
+
+RUN echo "Building GWMS Testbed image ($BUILD_SHA/$BUILD_DATE) on $BUILDPLATFORM, for $TARGETPLATFORM"
+
+# Installing some base packages, the CRB repo, and the EPEL (epel-release)
+RUN dnf install -y epel-release yum-utils python3 wget sed git jq vim zsh sudo psmisc bind-utils mlocate && \
+    dnf config-manager --set-enabled crb && \
+    /bin/sed -i '/^enabled=1/a priority=99' /etc/yum.repos.d/epel.repo
+
+# Installing some system management RPMs/sw needed for containers (these are not needed for VMs)
+RUN dnf install -y cronie supervisor initscripts ;\
+    /usr/bin/wget https://raw.githubusercontent.com/gdraheim/docker-systemctl-replacement/master/files/docker/systemctl3.py -O /usr/local/bin/systemctl ;\
+    /usr/bin/chmod +x /usr/local/bin/systemctl
+
+# Deploy GWMS aliases
+RUN /usr/bin/wget -O ~/.bash_aliases https://raw.githubusercontent.com/glideinWMS/dev-tools/master/.bash_aliases && \
+    . ~/.bash_aliases || true
+
+# Installing htgettoken from source
+RUN dnf -y install krb5-devel python3-devel gcc;\
+    git clone https://github.com/fermitools/htgettoken.git /opt/htgettoken && \
+    pip install /opt/htgettoken/
+
+# This must be after all dnf/yum and pip commands
+# Cleaning YUM and DNF all caches (including disabled repos) and pip caches to reduce size of image
+RUN rm -rf /var/cache/yum/* /var/cache/dnf/* /root/.cache/pip/*
+
+# Adding unprivileged users
+RUN adduser abc ;\
+    mkdir /home/abc/repos && \
+    chown abc: /home/abc/repos ;\
+    mkdir /opt/abc && \
+    chown abc: /opt/abc
+RUN useradd testuser
+COPY --chown=testuser:testuser frontend-workspace/testuser-home/* /home/testuser/
+
+# Deploy utility scripts
+COPY testbed-workspace/scripts /opt/scripts
+COPY shared/scripts/* /opt/scripts
+COPY frontend-workspace/scripts/run-test.sh /opt/scripts
+RUN ln -s /opt/scripts/* /usr/local/bin
+
+# Deploy GlideinWMS Frontend and HTCondor configuration
+RUN mkdir -p /opt/config/factory /opt/config/frontend
+COPY shared/config/* /opt/config
+COPY factory-workspace/config/glideinWMS.xml /opt/config/factory
+COPY frontend-workspace/config/frontend.xml /opt/config/frontend
+RUN sed -i "s/\[ARCH\]/$(arch)/g" /opt/config/factory/glideinWMS.xml
+
+# Deploy secrets
+COPY gwms-workspace/secrets /opt/localgwms/secrets
+
+# GWMS and OSG suggested mount points
+RUN mkdir -p /opt/gwms ; \
+    for MNTPOINT in \
+        /cvmfs \
+        /hadoop \
+        /hdfs \
+        /lizard \
+        /mnt/hadoop \
+        /mnt/hdfs \
+        /xenon \
+        /scratch \
+        /spt \
+        /stash2 \
+    ; do \
+        mkdir -p $MNTPOINT ; \
+    done
+
+# Default entry point
+CMD ["/bin/bash"]
+
+# build info
+RUN echo "Source: glideinwms/testbed-workspace" > /image-source-info.txt
+RUN echo "Timestamp: $(date -u +'%Y-%m-%dT%H:%M:%SZ')" | tee /image-build-info.txt

--- a/workspaces/testbed-workspace/scripts/install-factory.sh
+++ b/workspaces/testbed-workspace/scripts/install-factory.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+
+### INTRO ###
+
+# Environment
+OSG_VERSION=24
+OSG_REPO=osg
+GWMS_REPO=osg-development
+
+# Argument parser
+while [ -n "$1" ];do
+    case "$1" in
+        --osg-repo)
+            OSG_REPO="$2"
+            shift
+            ;;
+        --gwms-repo)
+            GWMS_REPO="$2"
+            shift
+            ;;
+        --osg-version)
+            OSG_VERSION="$2"
+            shift
+            ;;
+        *)
+            echo "Parameter '$1' is not supported."
+            exit 1
+    esac
+    shift
+done
+
+
+### REPOSITORIES ###
+
+# OSG Repo
+dnf -y install "https://repo.osg-htc.org/osg/$OSG_VERSION-main/osg-$OSG_VERSION-main-el9-release-latest.rpm"
+
+
+### INSTALLATION ###
+
+# OSG
+yum install -y osg-ca-certs --enablerepo="$OSG_REPO"
+
+# Factory
+dnf -y install glideinwms-factory --enablerepo="$GWMS_REPO"
+
+
+### CONFIGURATION ###
+
+# GlideinWMS Factory configuration
+GWMS_CONFIG=/etc/gwms-factory/glideinWMS.xml
+cp /opt/config/factory/glideinWMS.xml $GWMS_CONFIG
+chown gfactory.gfactory $GWMS_CONFIG
+echo Updated Factory configuration
+
+# HTCondor configuration
+cp /opt/config/99-debug.conf /etc/condor/config.d
+cp /opt/config/99-cafile.conf /etc/condor/config.d
+
+# Condor tarball
+CONDOR_TARBALL_URLS="
+https://research.cs.wisc.edu/htcondor/tarball/10/10.x/10.6.0/release/condor-10.6.0-$(arch)_AlmaLinux9-stripped.tar.gz
+https://research.cs.wisc.edu/htcondor/tarball/9.0/9.0.18/release/condor-9.0.18-x86_64_CentOS7-stripped.tar.gz
+"
+CONDOR_TARBALL_PATH=/var/lib/gwms-factory/condor
+[ ! -d $CONDOR_TARBALL_PATH ] && mkdir -p $CONDOR_TARBALL_PATH
+pushd $CONDOR_TARBALL_PATH || exit 3
+for CONDOR_TARBALL_URL in $CONDOR_TARBALL_URLS; do
+    wget "$CONDOR_TARBALL_URL"
+    CONDOR_TARBALL=$(echo "$CONDOR_TARBALL_URL" | awk -F'/' '{print $NF}')
+    tar -xf "$CONDOR_TARBALL"
+done
+popd || exit 4
+
+
+### STARTUP ###
+
+GWMS_DIR=/opt/gwms
+bash /opt/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
+bash /opt/scripts/create-idtokens.sh -a
+systemctl start httpd
+systemctl start condor
+gwms-factory upgrade
+systemctl start gwms-factory

--- a/workspaces/testbed-workspace/scripts/install-frontend.sh
+++ b/workspaces/testbed-workspace/scripts/install-frontend.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+
+### INTRO ###
+
+# Environment
+OSG_VERSION=24
+OSG_REPO=osg
+GWMS_REPO=osg-development
+
+# Argument parser
+while [ -n "$1" ];do
+    case "$1" in
+        --osg-repo)
+            OSG_REPO="$2"
+            shift
+            ;;
+        --gwms-repo)
+            GWMS_REPO="$2"
+            shift
+            ;;
+        --osg-version)
+            OSG_VERSION="$2"
+            shift
+            ;;
+        *)
+            echo "Parameter '$1' is not supported."
+            exit 1
+    esac
+    shift
+done
+
+
+### REPOSITORIES ###
+
+# OSG Repo
+dnf -y install "https://repo.osg-htc.org/osg/$OSG_VERSION-main/osg-$OSG_VERSION-main-el9-release-latest.rpm"
+
+
+### INSTALLATION ###
+
+# OSG
+yum install -y osg-ca-certs --enablerepo="$OSG_REPO"
+
+# Frontend
+dnf -y install glideinwms-vofrontend --enablerepo="$GWMS_REPO"
+
+
+### CONFIGURATION ###
+
+# GlideinWMS Frontend configuration
+GWMS_CONFIG=/etc/gwms-frontend/frontend.xml
+cp /opt/config/frontend/frontend.xml $GWMS_CONFIG
+chown frontend.frontend $GWMS_CONFIG
+echo Updated Frontend configuration
+
+# HTCondor configuration
+cp /opt/config/99-debug.conf /etc/condor/config.d
+cp /opt/config/99-cafile.conf /etc/condor/config.d
+
+
+### STARTUP ###
+
+GWMS_DIR=/opt/gwms
+bash /opt/scripts/create-host-certificate.sh -d "$GWMS_DIR"/secrets
+bash /opt/scripts/create-idtokens.sh -r
+bash /opt/scripts/create-scitoken.sh
+systemctl start httpd
+systemctl start condor
+gwms-frontend upgrade
+systemctl start gwms-frontend


### PR DESCRIPTION
This PR adds a new testbed workspace and a compose file to create a testbed environment for GlideinWMS.

The testbed environment consists of:
- testbed-ce-workspace (glideinwms/ce-workspace)
- testbed-factory-workspace (glideinwms/testbed-workspace)
- testbed-frontend-workspace (glideinwms/testbed-workspace)

The testbed-workspace image comes with installation scripts to install specific versions of OSG, HTCondor, and GlideinWMS.

**NOTE**: Even though we have a `testbed-frontend-workspace` and a `testbed-factory-workspace`, they are both based on the same `glideinwms/testbed-workspace` image and will only become a factory or a frontend when either `install-factory.sh` or `install-frontend.sh` are executed.