### PR TITLE
Add "ddd" to SL7 dev container

### DIFF
--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -14,7 +14,7 @@ RUN yum -y install asciidoc autoconf automake bzip2-devel fontconfig-devel freet
     python3-devel python-six emacs vim nano cvs htop curl procmail \
     autogen bison cmake3 gunzip hwloc-devel patchelf ninja-build csh tcsh zsh \
     java-latest-openjdk-devel \
-    mesa-dri-drivers
+    mesa-dri-drivers ddd
 
 # Packages requiring additional repos
 RUN curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.repo?os=centos&dist=7&source=script' > /etc/yum.repos.d/github_git-lfs.repo


### PR DESCRIPTION
As per RITM2345565 this PR is adding "ddd" to the SL7 dev container.
Trying a local build of the container it succeeds.