### PR TITLE
Fix pseudoterminal in unpriv namespace to run ddd

### DIFF
--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -16,12 +16,19 @@ RUN yum -y install asciidoc autoconf automake bzip2-devel fontconfig-devel freet
     java-latest-openjdk-devel \
     mesa-dri-drivers ddd
 
+# Fix pseudoterminal in unpriv. namespace; see https://github.com/apptainer/apptainer/issues/297
+RUN yum -y install https://linuxsoft.cern.ch/wlcg/centos7/x86_64/glibc-grantpt-fix-1.0.0-1.el7.cern.x86_64.rpm
+
 # Packages requiring additional repos
 RUN curl -sSf 'https://packagecloud.io/install/repositories/github/git-lfs/config_file.repo?os=centos&dist=7&source=script' > /etc/yum.repos.d/github_git-lfs.repo
 # Installed in sl7-base  RUN yum -y install yum-conf-context-fermilab.noarch
 RUN yum -y install fermilab-util_kx509 fermilab-conf_kerberos \
     git-lfs \
     && yum -y clean all
+
+# Add ddd alias to preload glibc-grantpt-fix library that allows ddd to run properly
+ADD shared/ddd.sh /etc/profile.d/ddd.sh
+ADD shared/ddd.csh /etc/profile.d/ddd.csh
 
 # Default entry point
 CMD ["/bin/bash"]

--- a/worker/shared/ddd.csh
+++ b/worker/shared/ddd.csh
@@ -1,0 +1,5 @@
+# preload libc_grantpt_fix.so for SL7 dev container
+# to fix pseudoterminal in unpriv. namespace;
+# see https://github.com/apptainer/apptainer/issues/297
+
+alias ddd 'env LD_PRELOAD=/usr/lib64/libc_grantpt_fix.so ddd'

--- a/worker/shared/ddd.sh
+++ b/worker/shared/ddd.sh
@@ -1,0 +1,5 @@
+# preload libc_grantpt_fix.so for SL7 dev container
+# to fix pseudoterminal in unpriv. namespace;
+# see https://github.com/apptainer/apptainer/issues/297
+
+alias ddd='LD_PRELOAD=/usr/lib64/libc_grantpt_fix.so ddd'


### PR DESCRIPTION
This address an issue with pseudoterminal in the container when running `ddd`.
This issue has been reported in https://github.com/apptainer/apptainer/issues/297

This PR adds an alias to preload the  glibc-grantpt-fix library.
To make the alias available in the container it is required to use a login shell like this:
```
apptainer exec <options>  <container> /bin/bash -l
``` 