### PR TITLE
Add script alias to preload patched glibc

### DIFF
--- a/worker/fnal-dev-sl7/Dockerfile
+++ b/worker/fnal-dev-sl7/Dockerfile
@@ -29,9 +29,11 @@ RUN yum -y install fermilab-util_kx509 fermilab-conf_kerberos \
     git-lfs \
     && yum -y clean all
 
-# Add ddd alias to preload glibc-grantpt-fix library that allows ddd to run properly
+# Add ddd and script aliases to preload glibc-grantpt-fix library that allows ddd and script to run properly
 ADD shared/ddd.sh /etc/profile.d/ddd.sh
 ADD shared/ddd.csh /etc/profile.d/ddd.csh
+ADD shared/script.sh /etc/profile.d/script.sh
+ADD shared/script.csh /etc/profile.d/script.csh
 
 # Default entry point
 CMD ["/bin/bash"]

--- a/worker/shared/script.csh
+++ b/worker/shared/script.csh
@@ -1,0 +1,5 @@
+# preload libc_grantpt_fix.so for SL7 dev container
+# to fix pseudoterminal in unpriv. namespace;
+# see https://github.com/apptainer/apptainer/issues/297
+
+alias script 'env LD_PRELOAD=/usr/lib64/libc_grantpt_fix.so script'

--- a/worker/shared/script.sh
+++ b/worker/shared/script.sh
@@ -1,0 +1,5 @@
+# preload libc_grantpt_fix.so for SL7 dev container
+# to fix pseudoterminal in unpriv. namespace;
+# see https://github.com/apptainer/apptainer/issues/297
+
+alias script='LD_PRELOAD=/usr/lib64/libc_grantpt_fix.so script'


### PR DESCRIPTION
This is a follow up of PR #65. 
Also `script` needs a patched glibc to run properly.
This is similar to what we did for `ddd`.