### PR TITLE
Install XRootD 5.7.3 from CERN XRootD repo

### DIFF
--- a/worker/fnal-wn-sl7/Dockerfile
+++ b/worker/fnal-wn-sl7/Dockerfile
@@ -25,6 +25,10 @@ LABEL name="FNAL Worker Node on SL7 with OSG 3.6 Worker Node Client"
 # removed:  gfal2-plugin-xrootd-2.18.1-2.el7.x86_64, verify why it was added, now also in OSG, it is a dependency of osg-wn-client
 # TODO: temporary using osg-development, should be removed after 11/5
 #  removed --enablerepo=osg-testing 2020-07-09
+
+# add CERN XRootD repo, this provides more recent version of XRootD packages for SL7
+RUN /usr/bin/wget https://cern.ch/xrootd/xrootd.repo -O /etc/yum.repos.d/xrootd.repo
+
 RUN yum install -y \
     osg-ca-certs \
     gcc-c++ libstdc++ xrootd-client-libs xrootd-libs xrootd-client osg-wn-client krb5-workstation strace redhat-lsb-core mesa-libGLU mesa-libGLU-devel libXmu cvmfs gstreamer-plugins-base libXScrnSaver libSM-devel libXpm-devel libgfortran glibc.i686 libXmu libXmu-devel expat-devel libxml2-devel mysql-libs libtiff libjpeg-turbo openssh-clients openssl-devel tzdata glibc-headers glibc-devel \


### PR DESCRIPTION
As per RITM2493585 this XRootD update has been approved to go in SL7 containers.