### PR TITLE
Install XRootD from direct links

### DIFF
--- a/worker/fnal-wn-sl7/Dockerfile
+++ b/worker/fnal-wn-sl7/Dockerfile
@@ -27,11 +27,18 @@ LABEL name="FNAL Worker Node on SL7 with OSG 3.6 Worker Node Client"
 #  removed --enablerepo=osg-testing 2020-07-09
 
 # add CERN XRootD repo, this provides more recent version of XRootD packages for SL7
-RUN /usr/bin/wget https://cern.ch/xrootd/xrootd.repo -O /etc/yum.repos.d/xrootd.repo
+# the repo doesn't work for SL7,
+# for details check https://github.com/xrootd/xrootd/issues/2546
+# RUN /usr/bin/wget https://cern.ch/xrootd/xrootd.repo -O /etc/yum.repos.d/xrootd.repo
+
+# instead install XRootD packages with direct URLs
 
 RUN yum install -y \
+    https://xrootd.web.cern.ch/repo/stable/el7/x86_64/xrootd-client-5.7.3-1.el7.x86_64.rpm \
+    https://xrootd.web.cern.ch/repo/stable/el7/x86_64/xrootd-client-libs-5.7.3-1.el7.x86_64.rpm \
+    https://xrootd.web.cern.ch/repo/stable/el7/x86_64/xrootd-libs-5.7.3-1.el7.x86_64.rpm \
     osg-ca-certs \
-    gcc-c++ libstdc++ xrootd-client-libs xrootd-libs xrootd-client osg-wn-client krb5-workstation strace redhat-lsb-core mesa-libGLU mesa-libGLU-devel libXmu cvmfs gstreamer-plugins-base libXScrnSaver libSM-devel libXpm-devel libgfortran glibc.i686 libXmu libXmu-devel expat-devel libxml2-devel mysql-libs libtiff libjpeg-turbo openssh-clients openssl-devel tzdata glibc-headers glibc-devel \
+    gcc-c++ libstdc++ osg-wn-client krb5-workstation strace redhat-lsb-core mesa-libGLU mesa-libGLU-devel libXmu cvmfs gstreamer-plugins-base libXScrnSaver libSM-devel libXpm-devel libgfortran glibc.i686 libXmu libXmu-devel expat-devel libxml2-devel mysql-libs libtiff libjpeg-turbo openssh-clients openssl-devel tzdata glibc-headers glibc-devel \
     pcre2 pcre2-devel xxhash-libs libzstd libzstd-devel mpich mpich-devel numactl numactl-devel libffi libffi-devel libcurl-devel \
     ftgl gl2ps libGLEW giflib libAfterImage \
     perl perl-autodie perl-Carp perl-constant perl-Data-Dumper perl-Digest perl-Digest-SHA perl-Exporter perl-File-Path perl-File-Temp perl-Getopt-Long perl-libs perl-PathTools perl-Scalar-List-Utils \


### PR DESCRIPTION
The XRootD repo for SL7 doesn't work. 
Install XRootD from direct links.